### PR TITLE
fix: missing type on enum and added bold color for better example

### DIFF
--- a/examples/simple.go
+++ b/examples/simple.go
@@ -8,11 +8,10 @@ import (
 )
 
 func main() {
-	b, _ := gradient.NewGradientBuilder(gradient.WithColors(lipgloss.Color("123"), lipgloss.Color("202")),
+	f, _ := gradient.NewGradientBuilder(gradient.WithColors(lipgloss.Color("#00FF00"), lipgloss.Color("#FF0000")),
 		gradient.WithDomain(0.0, 1.0)).Build()
 
-	b1, _ := gradient.NewGradientBuilder(gradient.WithColors(lipgloss.Color("253"), lipgloss.Color("129")),
-		gradient.WithDomain(0.0, 1.0)).Build()
+	b, _ := gradient.NewGradientBuilder(gradient.WithColors(lipgloss.Color("#FF0000"), lipgloss.Color("#00FF00")), gradient.WithDomain(0.0, 1.0)).Build()
 
-	fmt.Println(b1.RenderBackground(b.RenderForeground("Hello World")))
+	fmt.Println(b.RenderBackground(f.RenderForeground("This is Gradient String")))
 }

--- a/gradient.go
+++ b/gradient.go
@@ -13,7 +13,7 @@ const resetANSI = "\033[0m"
 type GradientDirection int
 
 const (
-	Horizontal = iota
+	Horizontal GradientDirection = iota
 	Vertical
 )
 


### PR DESCRIPTION
while reading source, i found that type `GradientDirection` is not mentioned on the enums, `Horizontal` and `Vertical`. 

![image](https://github.com/Delta456/gradient-string/assets/82411321/e88eeb2a-a32d-4b4d-a86a-27b02c7a92a4)
